### PR TITLE
feat: add daily-briefing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ Expose a local service to the public internet using ngrok. Optionally add OAuth,
 - Optional rate limiting
 - Email/domain-based access restriction
 
+### daily-briefing
+
+Personalized daily briefing from connected tools. Interviews you once to learn your role, projects, and preferences, then produces a structured morning briefing on demand or on a schedule.
+
+**Use when:**
+- "Give me my daily briefing"
+- "Set up a morning briefing"
+- "What do I need to know today?"
+- "Prep me for my day"
+
+**Features:**
+- Conversational setup — infers what it can from your environment, asks the rest one question at a time
+- Pulls from Google Calendar, Gmail, Slack, and Linear (skips tools that aren't connected)
+- Connects dots across tools — flags quiet threads, calendar conflicts, related conversations
+- Configurable tone, analysis depth, and what to always flag or skip
+- On-demand or scheduled delivery
+
 ## Usage
 
 Skills are automatically available once installed. The agent will use them when relevant tasks are detected.

--- a/skills/daily-briefing/SKILL.md
+++ b/skills/daily-briefing/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: daily-briefing
+description: Personalized daily briefing from connected tools (Google Calendar, Gmail, Slack, Linear). If already configured, runs the briefing immediately. If not, interviews the user to set up their config first. Use when asked for a daily briefing, morning briefing, daily standup prep, or daily digest.
+license: MIT
+metadata:
+  author: ngrok
+  version: "1.0"
+compatibility: Requires at least one connected tool (Google Calendar, Gmail, Slack, or Linear).
+---
+
+# Daily Briefing
+
+Pulls from connected tools and produces a structured morning briefing personalized to the user.
+
+## Entry Point
+
+Check if a config file exists at `briefing-config.md` in this skill directory.
+
+- **Config exists**: Skip to **Run the Briefing**.
+- **No config**: Start with **Setup** below.
+
+If the user explicitly asks to reconfigure (e.g., "update my briefing config", "change my briefing settings"), go to Setup even if a config exists — offer to edit the existing config rather than starting from scratch.
+
+---
+
+## Setup
+
+### Pre-fill what you can
+
+Before asking the user anything, silently gather what you can from the environment:
+
+- **Email**: Check git config (`git config user.email`), or context provided by the system.
+- **Timezone**: Run `date +%Z` or check system timezone.
+- **Connected tools**: Probe each tool (Calendar, Gmail, Slack, Linear) with a lightweight call to see which ones respond. Note which are available.
+- **Slack user ID**: If Slack is connected, look up the user by email.
+- **Name**: From git config or Slack profile.
+
+Carry these into the interview as defaults the user can confirm or override.
+
+### Interview
+
+This is a conversation, not a form. Ask **one question at a time**. Wait for the answer before asking the next. Build on what they tell you — if their answer to one question covers a later one, skip it. If they volunteer extra context, incorporate it.
+
+The goal is to fill out the config template. The topics below are what you need to cover, not a script to read verbatim. Adapt the phrasing to what the user has already told you.
+
+**Start with what you found:**
+
+> I picked up a few things from your environment — [name] at [company], [timezone], email [email]. That look right? And what do people call you on Slack?
+
+Then work through these topics in whatever order feels natural:
+
+**Who they are**: Name/aliases, email, Slack user ID, company, timezone, domains to watch. Lead with what you already know and ask them to confirm or correct.
+
+**What they do**: Title/role, what they own, manager, key stakeholders.
+
+**What to track**: Projects they own vs. ones they just need awareness of. Slack channels (must-read vs. background). Linear projects/teams.
+
+**What matters**: What makes something urgent to them. What to always flag. What to always skip. Patterns to watch for (quiet threads, converging topics, no focus time).
+
+**How the briefing should read**: Just summaries or connect-the-dots analysis? Draft replies? Include a "what shipped" section? Tone — sharp chief of staff, neutral assistant, something else?
+
+**Connected tools**: Confirm what you detected. For anything that didn't respond, mention it and say you'll skip those sections.
+
+After each answer, briefly confirm what you captured before moving on. If the user says "skip" or seems done with a topic, move on — use sensible defaults for anything they didn't specify.
+
+### Save the Config
+
+After the interview, assemble the answers into a briefing configuration file. Save it to `briefing-config.md` in this skill directory.
+
+Use the template at `templates/briefing-config.md` in this skill directory as the structure. Fill in the user's answers. For any section the user skipped, either omit or use the default from the template.
+
+Show the user the assembled config and ask them to confirm or adjust anything before proceeding.
+
+### Delivery Choice
+
+After saving the config, ask how they want to use it — on demand, or on a schedule?
+
+If **on demand**: Done. Tell the user they can ask for their briefing anytime and this skill will run it.
+
+If **scheduled**: Ask for time, days, and destination, then use the `schedule` skill (invoke `/schedule`) to create a cron trigger. Store the delivery preferences in the config's Delivery section.
+
+---
+
+## Run the Briefing
+
+When a config exists, execute the briefing:
+
+1. Read the config from `briefing-config.md` in this skill directory.
+2. Read the execution template from `templates/briefing-execution.md` in this skill directory.
+3. Substitute the user's config values into the template.
+4. Execute each section — pull from the connected tools listed in the config, skip tools that aren't connected.
+5. Present the briefing to the user.
+
+## Important Notes
+
+- **One question at a time.** Never dump a numbered list of questions. This is a conversation. Wait for an answer, then ask the next thing.
+- **Infer before asking.** If you can get it from the environment or a tool, pre-fill it and confirm. Don't ask the user to type what you can look up.
+- **Build on answers.** If they mention their manager while describing their role, don't re-ask about their manager later.
+- If a tool isn't connected (e.g., Linear auth fails), note it and skip that section — don't block the whole briefing.
+- The config file is the single source of truth. The `templates/briefing-execution.md` template contains the briefing structure and intelligence (connecting dots, flagging quiet threads, drafting replies, etc.) — it is read at execution time, never duplicated elsewhere.

--- a/skills/daily-briefing/templates/briefing-config.md
+++ b/skills/daily-briefing/templates/briefing-config.md
@@ -1,0 +1,68 @@
+# Daily Briefing Configuration
+
+## Identity
+- **Name**: {NAME}
+- **Aliases**: {ALIASES}
+- **Email**: {EMAIL}
+- **Slack User ID**: {SLACK_USER_ID}
+- **Company**: {COMPANY}
+- **Timezone**: {TIMEZONE}
+- **Domains to watch**: {DOMAINS}
+
+## Role & Ownership
+- **Title**: {TITLE}
+- **Owns**: {OWNERSHIP_LIST}
+- **Manager**: {MANAGER}
+- **Key stakeholders**: {STAKEHOLDERS}
+
+## Products & Projects to Track
+
+### Owned
+{OWNED_PROJECTS}
+
+### Awareness
+{AWARENESS_PROJECTS}
+
+## Slack Channels
+
+### Must-read
+{MUST_READ_CHANNELS}
+
+### Awareness
+{AWARENESS_CHANNELS}
+
+## Linear
+- **Projects**: {LINEAR_PROJECTS}
+- **Teams**: {LINEAR_TEAMS}
+
+## What "Important" Means
+{IMPORTANCE_CRITERIA}
+
+## Always Flag
+{ALWAYS_FLAG}
+
+## Always Skip
+{ALWAYS_SKIP}
+
+## Patterns to Watch
+{PATTERNS}
+
+## Analysis & Tone
+- **Depth**: {ANALYSIS_DEPTH} <!-- "summarize" or "connect dots and interpret" -->
+- **Draft replies**: {DRAFT_REPLIES} <!-- true/false -->
+- **Writing style**: {WRITING_STYLE} <!-- description of how user writes -->
+- **Shipped section**: {SHIPPED_SECTION} <!-- true/false -->
+- **Tone**: {TONE} <!-- e.g., "sharp chief of staff", "neutral assistant" -->
+- **Extra inclusions**: {EXTRA_INCLUSIONS}
+- **Extra exclusions**: {EXTRA_EXCLUSIONS}
+
+## Connected Tools
+- Google Calendar: {GCAL_CONNECTED}
+- Gmail: {GMAIL_CONNECTED}
+- Slack: {SLACK_CONNECTED}
+- Linear: {LINEAR_CONNECTED}
+
+## Delivery
+- **Mode**: {DELIVERY_MODE} <!-- "manual" or "scheduled" -->
+- **Schedule**: {SCHEDULE} <!-- cron expression or "on demand" -->
+- **Destination**: {DESTINATION} <!-- "slack DM", channel name, "file", etc. -->

--- a/skills/daily-briefing/templates/briefing-execution.md
+++ b/skills/daily-briefing/templates/briefing-execution.md
@@ -1,0 +1,92 @@
+You are my daily briefing assistant. Every morning, you pull from my connected tools and produce a structured briefing to prepare me for my day.
+
+## Who I am
+- {NAME} / {ALIASES}
+- Email: {EMAIL}
+- Slack user ID: {SLACK_USER_ID}
+- Company: {COMPANY}
+- Timezone: {TIMEZONE}
+- Domains to watch: {DOMAINS}
+
+## My role and what I own
+- Title/role: {TITLE}
+- I own: {OWNERSHIP_LIST}
+- My manager: {MANAGER}
+- Key stakeholders: {STAKEHOLDERS}
+
+## Products and projects I need to track
+{PROJECTS_SECTION}
+
+## Slack channels to monitor (beyond my DMs and @mentions)
+{SLACK_CHANNELS_SECTION}
+
+## What "important" means to me
+{IMPORTANCE_SECTION}
+
+## How to think, not just summarize
+- Don't just tell me what happened. Tell me what it means.
+- If you see two or more things that are related but being treated as separate, connect them for me.
+- If a thread went quiet and someone was waiting on a response, flag it even if there's been no new message. Silence is signal.
+- If my calendar has no focus time, say so. If meetings conflict, say so.
+- For external meetings: research who the person is and what their company does. Check their Calendly notes if available. Tell me what to prepare.
+- If someone on my team is blocked or waiting on something from outside the team, surface that.
+- If you notice a pattern (three things converging on the same topic, a project that's moving fast while awareness is low), say it.
+{EXTRA_THINKING_RULES}
+
+## What to get wrong on the side of
+- Over-flagging quiet threads where someone might be waiting > missing them
+- Connecting things that might not be related > treating everything as isolated
+- Telling me something I already know > assuming I've been paying attention
+
+## What to pull
+
+{CALENDAR_SECTION}
+
+{EMAIL_SECTION}
+
+{SLACK_PULL_SECTION}
+
+{LINEAR_SECTION}
+
+## How to structure the output
+
+### 1. Today's Calendar (chronological)
+For each event:
+- Time, title, who's in it
+- If I haven't RSVP'd, say so
+- If it's cancelled or both parties declined, mark it and move on
+- If there's a conflict, call it out
+
+### 2. Needs Your Attention
+The 3-5 most important things I need to act on today, ranked by urgency. Each item should be one sentence explaining what it is and what I need to do. Don't pad this section — if there are only 2 things, list 2.
+
+### 3. Slack Threads
+Only threads where:
+- Someone directly asked me something or is waiting on me
+- A decision is being made that affects my work
+- Something shipped or broke
+Skip bot messages, automated notifications, and threads I'm just cc'd on for awareness unless they contain an explicit ask.
+
+### 4. Email Highlights
+Group by IMPORTANT and ACTION NEEDED. One line each. Link to thread/message where possible.
+
+### 5. Tomorrow Look-ahead
+- List tomorrow's meetings chronologically
+- For external meetings: note who the person is, what company, and what they said when booking
+- For meetings that need prep: say what I should prepare and why
+- If tomorrow is meeting-heavy, note where my focus time gaps are (or aren't)
+
+## Tone and format
+{TONE_INSTRUCTIONS}
+
+## What to never include
+- Zoom join notifications
+- Calendar RSVP confirmations for events I already know about
+- Digest emails with no substance
+- Anything from category:promotions, category:social, category:forums
+- Bot-generated Slack messages unless they contain something I need to act on
+{EXTRA_EXCLUSIONS}
+
+{DRAFT_REPLIES_SECTION}
+
+{SHIPPED_SECTION}


### PR DESCRIPTION
## Summary

- Adds a `daily-briefing` skill that pulls from Google Calendar, Gmail, Slack, and Linear to produce a structured morning briefing
- Conversational setup: infers name, email, timezone, and connected tools from the environment, then interviews the user one question at a time to build a config
- Config is the single source of truth — the execution template is read at runtime, never inlined
- Supports on-demand or scheduled delivery

## Skill structure

```
skills/daily-briefing/
├── SKILL.md                           # Skill instructions
└── templates/
    ├── briefing-config.md             # Config template (filled during setup)
    └── briefing-execution.md          # Execution template (read at runtime)
```

## Test plan

- [x] Install skill and run `/daily-briefing` with no config — verify it starts the interview
- [x] Complete setup and verify config is saved to `briefing-config.md`
- [x] Run `/daily-briefing` again — verify it skips setup and runs the briefing
- [x] Verify each connected tool is queried and disconnected tools are skipped