### PR TITLE
Add front-door-auth skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ Expose a local service to the public internet using ngrok. Optionally add OAuth,
 - Optional rate limiting
 - Email/domain-based access restriction
 
+### front-door-auth
+
+Add OAuth to a service without writing OAuth code. ngrok runs as an auth-aware front door: a public cloud endpoint runs OAuth and forwards to a private internal endpoint backing your app, which reads two trusted identity headers.
+
+**Use when:**
+- "Add OAuth to my app without writing OAuth code"
+- "Delegate auth to ngrok"
+- "Use ngrok as an auth-aware API gateway"
+- "Set up auth at the edge"
+- "Front-door pattern"
+
+**Features:**
+- Generates `traffic-policy.yml` (OAuth + add-headers + forward-internal) and `ngrok.yml` (internal endpoint).
+- Drops trusted-header middleware into the project for Hono, Express, Fastify, Next.js, FastAPI, or Flask.
+- Creates the cloud endpoint via `ngrok api endpoints create` and starts the agent.
+- Optional email or domain allowlist enforced at the gateway.
+
 ## Usage
 
 Skills are automatically available once installed. The agent will use them when relevant tasks are detected.
@@ -39,6 +56,9 @@ Expose my app on port 3000 to the internet
 ```
 ```
 Share my local server with Google OAuth so only people at @mycompany.com can access it
+```
+```
+Add Google OAuth to my Hono app without writing any auth code
 ```
 
 ## Skill Structure

--- a/skills/front-door-auth/SKILL.md
+++ b/skills/front-door-auth/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: front-door-auth
-description: Add OAuth authentication to a service without writing OAuth code. Sets up ngrok as an auth-aware front door — a public cloud endpoint runs OAuth and forwards to a private internal endpoint backing the app, which reads two trusted identity headers. Use when asked to delegate auth to ngrok, add OAuth without writing code, set up auth at the edge, build an auth-aware API gateway, or apply the front-door pattern.
+description: Add OAuth authentication to a service without writing OAuth code. Sets up ngrok as an auth-aware front door. A public cloud endpoint runs OAuth and forwards to a private internal endpoint backing the app, which reads two trusted identity headers. Use when asked to delegate auth to ngrok, add OAuth without writing code, set up auth at the edge, build an auth-aware API gateway, or apply the front-door pattern.
 license: MIT
 metadata:
   author: ngrok
@@ -8,7 +8,7 @@ metadata:
 compatibility: Requires ngrok CLI installed and authenticated (authtoken + API key).
 ---
 
-# Front-Door Auth
+# Front-door auth
 
 Set up ngrok as an auth-aware front door for a service. A public cloud endpoint runs a Traffic Policy that does OAuth, identity propagation, and `forward-internal`. The app sits behind an internal endpoint (`*.internal`) that's only routable from inside the user's ngrok account. The app reads `X-Forwarded-User-Email` and `X-Forwarded-User-Name` and trusts them.
 
@@ -46,7 +46,7 @@ Inspect the project to identify:
 - Framework. Check `package.json` (Hono, Express, Fastify, Next.js), `requirements.txt` or `pyproject.toml` (FastAPI, Flask), `go.mod`, `Gemfile`, etc.
 - Port. Check entrypoint files, `.env`, `package.json` scripts, `docker-compose.yml`. Default to 3000 for Node/TS, 8000 for Python, 8080 for Go.
 
-Frameworks not covered in `references/frameworks/` are still supportable. The trusted-header pattern is identical across them — read `X-Forwarded-User-Email` and `X-Forwarded-User-Name`, gate routes on whether the email is present, attach the identity to request context.
+Frameworks not covered in `references/frameworks/` are still supportable. The trusted-header pattern is identical across them: read `X-Forwarded-User-Email` and `X-Forwarded-User-Name`, gate routes on whether the email is present, attach the identity to request context.
 
 ### Step 2: Ask the user upfront
 
@@ -133,7 +133,7 @@ endpoints:
       url: localhost:{PORT}
 ```
 
-The `.internal` URL suffix auto-infers internal binding, so no `bindings:` field is needed.
+The `.internal` URL suffix auto-infers internal binding, so you don't need a `bindings:` field.
 
 ### Step 5: Add trusted-header middleware
 
@@ -143,7 +143,7 @@ The middleware always:
 
 - Reads `x-forwarded-user-email` and `x-forwarded-user-name` (case-insensitive in most frameworks).
 - Returns 401 if the email is missing on protected routes.
-- Falls back to `email.split('@')[0]` for the name when missing — some providers don't return a name.
+- Falls back to `email.split('@')[0]` for the name when missing, since some providers don't return a name.
 - Attaches `{ email, name }` to the framework's request/context object for handlers to use.
 
 Apply the middleware only to the routes the user said are protected. Leave public routes unmiddlewared.
@@ -158,7 +158,7 @@ ngrok api endpoints create \
   --traffic-policy-file traffic-policy.yml
 ```
 
-Capture the returned endpoint ID — the user will need it to push policy edits later.
+Capture the returned endpoint ID. The user will need it to push policy edits later.
 
 If this fails, see `references/troubleshooting.md`.
 
@@ -175,7 +175,7 @@ The internal endpoint at `{INTERNAL_NAME}.internal` is now serving the app.
 
 Tell the user:
 
-> Visit https://{DEV_DOMAIN}. You'll be redirected to {PROVIDER} to log in. After that, the app reads `X-Forwarded-User-Email` from each request. The cloud endpoint ID is `{ENDPOINT_ID}` — keep it for pushing policy edits.
+> Visit https://{DEV_DOMAIN}. You'll be redirected to {PROVIDER} to log in. After that, the app reads `X-Forwarded-User-Email` from each request. The cloud endpoint ID is `{ENDPOINT_ID}`. Keep it for pushing policy edits.
 
 ## Pushing policy edits
 
@@ -196,19 +196,25 @@ pkill ngrok
 
 ## Graduating to production
 
-The cloud endpoint is already permanent — it lives in the user's ngrok account, not the agent. The local agent is the only ephemeral piece.
+The cloud endpoint is already permanent. It lives in the user's ngrok account, not the agent. The local agent is the only ephemeral piece.
 
-- **Always-on local:** `sudo ngrok service install --config ~/.config/ngrok/ngrok.yml && sudo ngrok service start`
-- **Kubernetes / multi-instance:** deploy the agent as a sidecar (or its own deployment) with the same `ngrok.yml`. Multiple agents serving the same internal endpoint URL pool automatically.
+For an always-on local agent, install it as a service:
+
+```bash
+sudo ngrok service install --config ~/.config/ngrok/ngrok.yml
+sudo ngrok service start
+```
+
+For Kubernetes or multi-instance setups, deploy the agent as a sidecar (or its own deployment) with the same `ngrok.yml`. Multiple agents serving the same internal endpoint URL pool automatically.
 
 The cloud endpoint, the Traffic Policy, and the app code don't change.
 
 ## Reference
 
-- `references/frameworks/hono.md` — Hono middleware
-- `references/frameworks/express.md` — Express middleware
-- `references/frameworks/fastify.md` — Fastify pre-handler
-- `references/frameworks/nextjs.md` — Next.js middleware (App Router)
-- `references/frameworks/fastapi.md` — FastAPI dependency
-- `references/frameworks/flask.md` — Flask decorator
-- `references/troubleshooting.md` — Common errors
+- `references/frameworks/hono.md`: Hono middleware
+- `references/frameworks/express.md`: Express middleware
+- `references/frameworks/fastify.md`: Fastify pre-handler
+- `references/frameworks/nextjs.md`: Next.js middleware (App Router)
+- `references/frameworks/fastapi.md`: FastAPI dependency
+- `references/frameworks/flask.md`: Flask decorator
+- `references/troubleshooting.md`: Common errors

--- a/skills/front-door-auth/SKILL.md
+++ b/skills/front-door-auth/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: front-door-auth
+description: Add OAuth authentication to a service without writing OAuth code. Sets up ngrok as an auth-aware front door — a public cloud endpoint runs OAuth and forwards to a private internal endpoint backing the app, which reads two trusted identity headers. Use when asked to delegate auth to ngrok, add OAuth without writing code, set up auth at the edge, build an auth-aware API gateway, or apply the front-door pattern.
+license: MIT
+metadata:
+  author: ngrok
+  version: "1.0"
+compatibility: Requires ngrok CLI installed and authenticated (authtoken + API key).
+---
+
+# Front-Door Auth
+
+Set up ngrok as an auth-aware front door for a service. A public cloud endpoint runs a Traffic Policy that does OAuth, identity propagation, and `forward-internal`. The app sits behind an internal endpoint (`*.internal`) that's only routable from inside the user's ngrok account. The app reads `X-Forwarded-User-Email` and `X-Forwarded-User-Name` and trusts them.
+
+```
+[ public ] → [ cloud endpoint + Traffic Policy ] → [ internal endpoint ] → [ app ]
+```
+
+## When to use
+
+- "Add OAuth to my app without writing OAuth code"
+- "Delegate auth to ngrok"
+- "Use ngrok as an auth-aware API gateway"
+- "Set up auth at the edge"
+- "Front-door pattern"
+
+## When NOT to use
+
+- The user just wants to expose a local service. Use `expose-localhost` instead.
+- The user needs in-app logout, MFA enrollment, RBAC mutation, or password resets. Those need a real IdP.
+- The app is on a host with a publicly reachable address (e.g., `0.0.0.0` binding behind a public load balancer). The trust boundary breaks.
+
+## Prerequisites
+
+- ngrok CLI installed
+- Authtoken: `ngrok config add-authtoken <TOKEN>` (get at https://dashboard.ngrok.com/get-started/your-authtoken)
+- API key: `ngrok config add-api-key <KEY>` (get at https://dashboard.ngrok.com/api-keys)
+- Free dev domain (every account gets one on signup; find at https://dashboard.ngrok.com/domains)
+
+## Workflow
+
+### Step 1: Detect framework and port
+
+Inspect the project to identify:
+
+- Framework. Check `package.json` (Hono, Express, Fastify, Next.js), `requirements.txt` or `pyproject.toml` (FastAPI, Flask), `go.mod`, `Gemfile`, etc.
+- Port. Check entrypoint files, `.env`, `package.json` scripts, `docker-compose.yml`. Default to 3000 for Node/TS, 8000 for Python, 8080 for Go.
+
+Frameworks not covered in `references/frameworks/` are still supportable. The trusted-header pattern is identical across them — read `X-Forwarded-User-Email` and `X-Forwarded-User-Name`, gate routes on whether the email is present, attach the identity to request context.
+
+### Step 2: Ask the user upfront
+
+Ask all questions in one block before doing anything:
+
+```
+Front-door auth setup. A few details:
+
+1. Provider: Google, GitHub, Microsoft, GitLab, LinkedIn, or Twitch?
+2. Allowlist: Anyone who can log in, or restrict to a specific email or domain?
+3. Dev domain: What's your dev domain? (find at https://dashboard.ngrok.com/domains)
+4. Internal endpoint name: I'll call it `<your-app>.internal`. OK or pick another?
+5. Protected routes: Which paths need auth? (default: everything except `/`, `/health`, `/public/*`)
+```
+
+Confirm with a Y/n before proceeding.
+
+### Step 3: Write `traffic-policy.yml`
+
+Create at the project root. Substitute the user's answers into the template below.
+
+```yaml
+on_http_request:
+  # Require OAuth on protected routes.
+  - expressions:
+      - "{PATH_EXPRESSION}"
+    actions:
+      - type: oauth
+        config:
+          provider: {PROVIDER}
+
+  # Inject the verified identity into headers the app trusts.
+  - expressions:
+      - "actions.ngrok.oauth.identity.email != ''"
+    actions:
+      - type: add-headers
+        config:
+          headers:
+            X-Forwarded-User-Email: "${actions.ngrok.oauth.identity.email}"
+            X-Forwarded-User-Name: "${actions.ngrok.oauth.identity.name}"
+
+  # OPTIONAL: deny anyone outside the allowlist (only include if the user asked for one).
+  - expressions:
+      - "actions.ngrok.oauth.identity.email != ''"
+      - "{ALLOWLIST_EXPRESSION}"
+    actions:
+      - type: deny
+        config:
+          status_code: 403
+
+  # Forward to the internal endpoint that backs the app.
+  - actions:
+      - type: forward-internal
+        config:
+          url: https://{INTERNAL_NAME}.internal
+```
+
+**Building `{PATH_EXPRESSION}`:** OR together each protected prefix using `req.url.path.startsWith('...')`. Example for `/me` and `/private`:
+
+```
+req.url.path.startsWith('/me') || req.url.path.startsWith('/private')
+```
+
+If the user gave a list of public paths instead of protected ones, invert: gate everything that does NOT match a public prefix.
+
+**Building `{ALLOWLIST_EXPRESSION}`:**
+
+- Single email: `actions.ngrok.oauth.identity.email != 'user@example.com'`
+- Email domain: `!actions.ngrok.oauth.identity.email.endsWith('@yourcompany.com')`
+- Multiple emails: `!(actions.ngrok.oauth.identity.email in ['a@x.com', 'b@x.com'])`
+
+### Step 4: Write `ngrok.yml`
+
+Create at `~/.config/ngrok/ngrok.yml` if it doesn't exist, or add to the existing one. Use v3 syntax:
+
+```yaml
+version: 3
+agent:
+  authtoken: {AUTHTOKEN}
+endpoints:
+  - name: app
+    url: https://{INTERNAL_NAME}.internal
+    upstream:
+      url: localhost:{PORT}
+```
+
+The `.internal` URL suffix auto-infers internal binding, so no `bindings:` field is needed.
+
+### Step 5: Add trusted-header middleware
+
+Open `references/frameworks/{framework}.md` for the project's framework and apply the snippet. Place the middleware in a sensible location for the project's structure (e.g., `src/middleware/auth.ts` for a TS project, or inline in the entry file for tiny apps).
+
+The middleware always:
+
+- Reads `x-forwarded-user-email` and `x-forwarded-user-name` (case-insensitive in most frameworks).
+- Returns 401 if the email is missing on protected routes.
+- Falls back to `email.split('@')[0]` for the name when missing — some providers don't return a name.
+- Attaches `{ email, name }` to the framework's request/context object for handlers to use.
+
+Apply the middleware only to the routes the user said are protected. Leave public routes unmiddlewared.
+
+### Step 6: Create the cloud endpoint
+
+```bash
+ngrok api endpoints create \
+  --type cloud \
+  --bindings public \
+  --url https://{DEV_DOMAIN} \
+  --traffic-policy-file traffic-policy.yml
+```
+
+Capture the returned endpoint ID — the user will need it to push policy edits later.
+
+If this fails, see `references/troubleshooting.md`.
+
+### Step 7: Start the agent
+
+```bash
+ngrok start --all &
+sleep 3
+```
+
+The internal endpoint at `{INTERNAL_NAME}.internal` is now serving the app.
+
+### Step 8: Confirm
+
+Tell the user:
+
+> Visit https://{DEV_DOMAIN}. You'll be redirected to {PROVIDER} to log in. After that, the app reads `X-Forwarded-User-Email` from each request. The cloud endpoint ID is `{ENDPOINT_ID}` — keep it for pushing policy edits.
+
+## Pushing policy edits
+
+If the user changes `traffic-policy.yml` after setup, the cloud endpoint won't pick up the change automatically. Push it:
+
+```bash
+ngrok api endpoints update {ENDPOINT_ID} --traffic-policy-file traffic-policy.yml
+```
+
+If the ID isn't known, find it: `ngrok api endpoints list`.
+
+## Teardown
+
+```bash
+ngrok api endpoints delete {ENDPOINT_ID}
+pkill ngrok
+```
+
+## Graduating to production
+
+The cloud endpoint is already permanent — it lives in the user's ngrok account, not the agent. The local agent is the only ephemeral piece.
+
+- **Always-on local:** `sudo ngrok service install --config ~/.config/ngrok/ngrok.yml && sudo ngrok service start`
+- **Kubernetes / multi-instance:** deploy the agent as a sidecar (or its own deployment) with the same `ngrok.yml`. Multiple agents serving the same internal endpoint URL pool automatically.
+
+The cloud endpoint, the Traffic Policy, and the app code don't change.
+
+## Reference
+
+- `references/frameworks/hono.md` — Hono middleware
+- `references/frameworks/express.md` — Express middleware
+- `references/frameworks/fastify.md` — Fastify pre-handler
+- `references/frameworks/nextjs.md` — Next.js middleware (App Router)
+- `references/frameworks/fastapi.md` — FastAPI dependency
+- `references/frameworks/flask.md` — Flask decorator
+- `references/troubleshooting.md` — Common errors

--- a/skills/front-door-auth/references/frameworks/express.md
+++ b/skills/front-door-auth/references/frameworks/express.md
@@ -1,0 +1,30 @@
+# Express
+
+```js
+import express from 'express'
+
+const app = express()
+
+const EMAIL_HEADER = 'x-forwarded-user-email'
+const NAME_HEADER = 'x-forwarded-user-name'
+
+function requireAuth(req, res, next) {
+  const email = req.header(EMAIL_HEADER)
+  if (!email) return res.status(401).json({ error: 'Unauthorized' })
+  req.identity = {
+    email,
+    name: req.header(NAME_HEADER) ?? email.split('@')[0],
+  }
+  next()
+}
+
+app.get('/', (_, res) => res.send('Public'))
+app.get('/me', requireAuth, (req, res) => res.json(req.identity))
+app.get('/private', requireAuth, (req, res) => {
+  res.send(`Hello, ${req.identity.name}`)
+})
+
+app.listen(3000)
+```
+
+Apply `requireAuth` only to the routes the user said are protected. For TypeScript, augment the `Request` type with `identity?: { email: string; name: string }`.

--- a/skills/front-door-auth/references/frameworks/fastapi.md
+++ b/skills/front-door-auth/references/frameworks/fastapi.md
@@ -1,0 +1,32 @@
+# FastAPI
+
+```python
+from fastapi import FastAPI, Depends, HTTPException, Request
+
+app = FastAPI()
+
+
+def require_auth(request: Request) -> dict:
+    email = request.headers.get("x-forwarded-user-email")
+    if not email:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    name = request.headers.get("x-forwarded-user-name") or email.split("@")[0]
+    return {"email": email, "name": name}
+
+
+@app.get("/")
+def public():
+    return "Public"
+
+
+@app.get("/me")
+def me(identity: dict = Depends(require_auth)):
+    return identity
+
+
+@app.get("/private")
+def private(identity: dict = Depends(require_auth)):
+    return f"Hello, {identity['name']}"
+```
+
+Apply `Depends(require_auth)` only on protected routes. For typed identity, define a `pydantic.BaseModel` and have `require_auth` return it.

--- a/skills/front-door-auth/references/frameworks/fastify.md
+++ b/skills/front-door-auth/references/frameworks/fastify.md
@@ -1,0 +1,29 @@
+# Fastify
+
+```js
+import Fastify from 'fastify'
+
+const fastify = Fastify()
+
+const EMAIL_HEADER = 'x-forwarded-user-email'
+const NAME_HEADER = 'x-forwarded-user-name'
+
+async function requireAuth(req, reply) {
+  const email = req.headers[EMAIL_HEADER]
+  if (!email) return reply.code(401).send({ error: 'Unauthorized' })
+  req.identity = {
+    email,
+    name: req.headers[NAME_HEADER] ?? email.split('@')[0],
+  }
+}
+
+fastify.get('/', async () => 'Public')
+fastify.get('/me', { preHandler: requireAuth }, async (req) => req.identity)
+fastify.get('/private', { preHandler: requireAuth }, async (req) => {
+  return `Hello, ${req.identity.name}`
+})
+
+fastify.listen({ port: 3000 })
+```
+
+Use `preHandler` (not `preValidation` or `onRequest`) so the identity is available when the handler runs. For TypeScript, decorate the request via `fastify.decorateRequest('identity', null)`.

--- a/skills/front-door-auth/references/frameworks/flask.md
+++ b/skills/front-door-auth/references/frameworks/flask.md
@@ -1,0 +1,41 @@
+# Flask
+
+```python
+from functools import wraps
+from flask import Flask, request, jsonify, abort, g
+
+app = Flask(__name__)
+
+
+def require_auth(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        email = request.headers.get("X-Forwarded-User-Email")
+        if not email:
+            abort(401)
+        g.identity = {
+            "email": email,
+            "name": request.headers.get("X-Forwarded-User-Name") or email.split("@")[0],
+        }
+        return f(*args, **kwargs)
+    return wrapper
+
+
+@app.get("/")
+def public():
+    return "Public"
+
+
+@app.get("/me")
+@require_auth
+def me():
+    return jsonify(g.identity)
+
+
+@app.get("/private")
+@require_auth
+def private():
+    return f"Hello, {g.identity['name']}"
+```
+
+Apply `@require_auth` only to protected routes. The decorator stashes identity on `flask.g`, which is request-scoped.

--- a/skills/front-door-auth/references/frameworks/hono.md
+++ b/skills/front-door-auth/references/frameworks/hono.md
@@ -1,0 +1,39 @@
+# Hono
+
+```ts
+import { Hono } from 'hono'
+
+type Identity = { email: string; name: string }
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    identity: Identity
+  }
+}
+
+const app = new Hono()
+
+const EMAIL_HEADER = 'x-forwarded-user-email'
+const NAME_HEADER = 'x-forwarded-user-name'
+
+function requireAuth() {
+  return async (c: any, next: () => Promise<void>) => {
+    const email = c.req.header(EMAIL_HEADER)
+    if (!email) return c.json({ error: 'Unauthorized' }, 401)
+    const name = c.req.header(NAME_HEADER) ?? email.split('@')[0]
+    c.set('identity', { email, name })
+    await next()
+  }
+}
+
+app.get('/', (c) => c.text('Public'))
+app.get('/me', requireAuth(), (c) => c.json(c.get('identity')))
+app.get('/private', requireAuth(), (c) => {
+  const { name } = c.get('identity')
+  return c.text(`Hello, ${name}`)
+})
+
+export default { port: 3000, fetch: app.fetch }
+```
+
+Apply `requireAuth()` only to the routes the user said are protected. Leave public routes unmiddlewared.

--- a/skills/front-door-auth/references/frameworks/nextjs.md
+++ b/skills/front-door-auth/references/frameworks/nextjs.md
@@ -1,0 +1,53 @@
+# Next.js (App Router)
+
+Two pieces: middleware that gates protected routes, and `headers()` reads in server components or route handlers.
+
+## Middleware
+
+`middleware.ts` at the project root:
+
+```ts
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const PROTECTED = ['/me', '/private']
+
+export function middleware(req: NextRequest) {
+  if (!PROTECTED.some((p) => req.nextUrl.pathname.startsWith(p))) {
+    return NextResponse.next()
+  }
+  const email = req.headers.get('x-forwarded-user-email')
+  if (!email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return NextResponse.next()
+}
+```
+
+## Reading identity in a server component
+
+```ts
+import { headers } from 'next/headers'
+
+export default async function MePage() {
+  const h = await headers()
+  const email = h.get('x-forwarded-user-email')!
+  const name = h.get('x-forwarded-user-name') ?? email.split('@')[0]
+  return <div>Hello, {name}</div>
+}
+```
+
+## Reading identity in a route handler
+
+```ts
+import { headers } from 'next/headers'
+
+export async function GET() {
+  const h = await headers()
+  const email = h.get('x-forwarded-user-email')!
+  const name = h.get('x-forwarded-user-name') ?? email.split('@')[0]
+  return Response.json({ email, name })
+}
+```
+
+The middleware enforces the boundary; the `headers()` reads attach identity to handlers. Don't read these headers from `Request.headers` in client components — they're not available there.

--- a/skills/front-door-auth/references/frameworks/nextjs.md
+++ b/skills/front-door-auth/references/frameworks/nextjs.md
@@ -50,4 +50,4 @@ export async function GET() {
 }
 ```
 
-The middleware enforces the boundary; the `headers()` reads attach identity to handlers. Don't read these headers from `Request.headers` in client components — they're not available there.
+The middleware enforces the boundary; the `headers()` reads attach identity to handlers. Don't read these headers from `Request.headers` in client components. They're not available there.

--- a/skills/front-door-auth/references/troubleshooting.md
+++ b/skills/front-door-auth/references/troubleshooting.md
@@ -1,0 +1,54 @@
+# Troubleshooting
+
+## `ERR_NGROK_15013` when creating the cloud endpoint
+
+The user has no dev domain yet. Tell them to claim the free one at https://dashboard.ngrok.com/domains, then retry the `ngrok api endpoints create` command.
+
+## `401 Unauthorized` from `ngrok api endpoints create`
+
+No API key configured. Tell the user to run:
+
+```bash
+ngrok config add-api-key <KEY>
+```
+
+Get the key at https://dashboard.ngrok.com/api-keys.
+
+## "Domain already in use"
+
+The dev domain is already attached to another endpoint. Either pick a different domain or delete the existing endpoint:
+
+```bash
+ngrok api endpoints list
+ngrok api endpoints delete <ENDPOINT_ID>
+```
+
+## App returns 401 after a successful login
+
+- Confirm the cloud endpoint forwards to the same `*.internal` URL the agent is serving. Mismatch is the most common cause.
+- Confirm the agent is running (`ngrok start --all`). If it isn't, the cloud endpoint can't forward anywhere.
+- Confirm the policy includes the `add-headers` rule. Without it, the app sees no identity headers and the middleware returns 401.
+
+## App shows "Hello, undefined"
+
+The `X-Forwarded-User-Name` header is missing. Some providers don't return a name for all users. The middleware should fall back to `email.split('@')[0]` — check the snippet in `references/frameworks/{framework}.md` and confirm the fallback is in place.
+
+## Edits to `traffic-policy.yml` aren't taking effect
+
+The cloud endpoint holds its own copy of the policy from when you created it. Push the edit:
+
+```bash
+ngrok api endpoints list
+ngrok api endpoints update <ENDPOINT_ID> --traffic-policy-file traffic-policy.yml
+```
+
+## `forward-internal` action fails with "no matching endpoint"
+
+The internal endpoint isn't running. Either:
+
+- The agent isn't running — `ngrok start --all`.
+- The agent's `ngrok.yml` has a different URL than the policy's `forward-internal.config.url`. They must match exactly, including scheme.
+
+## Plan limit blocks a Traffic Policy action
+
+Tell the user which action the plan blocks. The core front-door pattern uses only `oauth`, `add-headers`, `forward-internal`, and `deny`, all of which are available on the free plan as of this writing. If the user added an action that's plan-gated (e.g., `owasp-crs-request`), offer to remove it.

--- a/skills/front-door-auth/references/troubleshooting.md
+++ b/skills/front-door-auth/references/troubleshooting.md
@@ -31,7 +31,7 @@ ngrok api endpoints delete <ENDPOINT_ID>
 
 ## App shows "Hello, undefined"
 
-The `X-Forwarded-User-Name` header is missing. Some providers don't return a name for all users. The middleware should fall back to `email.split('@')[0]` — check the snippet in `references/frameworks/{framework}.md` and confirm the fallback is in place.
+The `X-Forwarded-User-Name` header is missing. Some providers don't return a name for all users. The middleware should fall back to `email.split('@')[0]`. Check the snippet in `references/frameworks/{framework}.md` and confirm the fallback is in place.
 
 ## Edits to `traffic-policy.yml` aren't taking effect
 
@@ -46,7 +46,7 @@ ngrok api endpoints update <ENDPOINT_ID> --traffic-policy-file traffic-policy.ym
 
 The internal endpoint isn't running. Either:
 
-- The agent isn't running — `ngrok start --all`.
+- The agent isn't running. Start it with `ngrok start --all`.
 - The agent's `ngrok.yml` has a different URL than the policy's `forward-internal.config.url`. They must match exactly, including scheme.
 
 ## Plan limit blocks a Traffic Policy action


### PR DESCRIPTION
## Summary
- Adds a new `front-door-auth` skill that sets up ngrok as an auth-aware front door (public cloud endpoint runs OAuth and forwards to a private internal endpoint backing the app, which trusts two identity headers).
- Includes a `SKILL.md` workflow plus framework references for Hono, Express, Fastify, Next.js, FastAPI, Flask, and a troubleshooting guide.
- Applies the ngrok style guide: sentence-case H1, no spaced em dashes, active voice, and prose in place of bolded-label lists.

## Test plan
- [ ] Walk through the SKILL.md workflow against a sample app to confirm the steps still produce a working cloud + internal endpoint pair.